### PR TITLE
Fixed loading Classes into Pics combobox

### DIFF
--- a/src/modules/ParseRepoData.py
+++ b/src/modules/ParseRepoData.py
@@ -46,7 +46,7 @@ class ParseRepoDataVanilla():
                 trainer_encounter_music_id_list.append(trainer_encounter_music_id)
         
         return {
-            'TRAINER_PIC': trainer_class_id_list,
+            'TRAINER_PIC': trainer_pic_id_list,
             'TRAINER_CLASS': trainer_class_id_list,
             'TRAINER_ENCOUNTER_MUSIC': trainer_encounter_music_id_list
         }


### PR DESCRIPTION
A bug in parse_trainer_info_file (src/modules/ParseRepoData.py) loaded the Trainer Class list into the Trainer Pic combobox, so when switching the Trainer Pic an exception is thrown.

Solution:
Replaced the return value to trainer_class_id_list.